### PR TITLE
Add automated PR creation on upstream updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+assets/resources/scriptlets.js @pes10k
+src/web_accessible_resources/* @pes10k
+src/js/redirect-engine.js @pes10k

--- a/.github/workflows/assign-pr.yml
+++ b/.github/workflows/assign-pr.yml
@@ -1,0 +1,11 @@
+on:
+  pull_request:
+    types: [opened, reopened]
+name: Assign Pull Request
+jobs:
+  assignAuthor:
+    name: Assign author to PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign author to PR
+        uses: technote-space/assign-author@v1

--- a/.github/workflows/check-for-changes.yml
+++ b/.github/workflows/check-for-changes.yml
@@ -1,0 +1,26 @@
+name: Check for Changes
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 9 * * *'
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    env:
+      FILES_TO_CHECK: "assets/resources/scriptlets.js|web_accessible_resources/|js/redirect-engine.js"
+      UPSTREAM_URL: "https://github.com/gorhill/ublock.git"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch release version
+        run: |
+          git remote add upstream ${UPSTREAM_URL}
+          git fetch upstream && git diff --name-only --diff-filter AM HEAD..remotes/upstream/main > updatedfiles.txt
+      - name: Check for modified files
+        id: git-check
+        run: echo ::set-output name=changes_present::$(if grep -qE "${FILES_TO_CHECK}" updatedfiles.txt; then echo 'true'; else echo 'false'; fi)
+      - name: show files
+        run: cat updatedfiles.txt
+      - name: Have files changed
+        if: steps.git-check.outputs.changes_present == 'false'
+        run: exit 1

--- a/.github/workflows/check-for-changes.yml
+++ b/.github/workflows/check-for-changes.yml
@@ -5,7 +5,7 @@ on:
     - cron:  '0 9 * * *'
 
 jobs:
-  get-version:
+  checkForChanges:
     runs-on: ubuntu-latest
     env:
       FILES_TO_CHECK: "assets/resources/scriptlets.js|web_accessible_resources/|js/redirect-engine.js"

--- a/.github/workflows/generate-sync-pr.yml
+++ b/.github/workflows/generate-sync-pr.yml
@@ -1,0 +1,21 @@
+name: Generate Sync PR for Fork
+
+on:
+  workflow_run:
+    workflows:
+      - Check for Changes
+    types:
+      - completed
+
+jobs:
+  sync:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tgymnich/fork-sync@v1.6.3
+        with:
+          owner: gorhill
+          base: master
+          head: master
+          auto_approve: false
+          ignore_fail: true


### PR DESCRIPTION
Resolves https://github.com/brave/devops/issues/6097 for Security Review

Run periodically at a set schedule (started at once per day), and check for updates against the upstream of this fork. 

Updates are parsed for specific files and locations as set in the actions variable `FILES_TO_CHECK`, and if these have been modified, it will trigger the generation of a PR assigned to a specific user defined in `codeowners`. 