### PR TITLE
Fix correct branch name

### DIFF
--- a/.github/workflows/check-for-changes.yml
+++ b/.github/workflows/check-for-changes.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Fetch release version
         run: |
           git remote add upstream ${UPSTREAM_URL}
-          git fetch upstream && git diff --name-only --diff-filter AM HEAD..remotes/upstream/main > updatedfiles.txt
+          git fetch upstream && git diff --name-only --diff-filter AM HEAD..remotes/upstream/master > updatedfiles.txt
       - name: Check for modified files
         id: git-check
         run: echo ::set-output name=changes_present::$(if grep -qE "${FILES_TO_CHECK}" updatedfiles.txt; then echo 'true'; else echo 'false'; fi)


### PR DESCRIPTION
Fixes the github action which mistakenly was looking for a `main` branch rather than `master`. A left over from testing this in isolation.