### PR TITLE
nooparrayfn instead of noopfn for getTargeting

### DIFF
--- a/src/web_accessible_resources/googletagservices_gpt.js
+++ b/src/web_accessible_resources/googletagservices_gpt.js
@@ -73,7 +73,7 @@
         enableVideoAds: noopfn,
         get: noopnullfn,
         getAttributeKeys: nooparrayfn,
-        getTargeting: noopfn,
+        getTargeting: nooparrayfn,
         getTargetingKeys: nooparrayfn,
         getSlots: nooparrayfn,
         refresh: noopfn,


### PR DESCRIPTION
https://developers.google.com/publisher-tag/reference#googletag.PubAdsService_getTargeting

I considered changing value of `get()` to be empty string instead of null, but on more thought a calling script SHOULD be checking for null values for that method according to the signature, so left it alone. 