### PR TITLE
Add `jsonpath.js` and `arglist-parser.js` to watched files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,5 @@ assets/assets.json @thypon
 assets/resources/scriptlets.js @thypon
 web_accessible_resources/* @thypon
 js/redirect-resources.js @thypon
+js/jsonpath.js @thypon
+js/arglist-parser.js @thypon

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,4 @@ web_accessible_resources/* @thypon
 js/redirect-resources.js @thypon
 js/jsonpath.js @thypon
 js/arglist-parser.js @thypon
+js/urlskip.js @thypon

--- a/.github/workflows/sync-from-fork.yml
+++ b/.github/workflows/sync-from-fork.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     env:
-      FILES_TO_CHECK: "assets/assets.json|src/web_accessible_resources/|src/js/resources/|src/js/redirect-resources.js|src/js/jsonpath.js|src/js/arglist-parser.js"
+      FILES_TO_CHECK: "assets/assets.json|src/web_accessible_resources/|src/js/resources/|src/js/redirect-resources.js|src/js/jsonpath.js|src/js/arglist-parser.js|src/js/urlskip.js"
       UPSTREAM_URL: "https://github.com/gorhill/ublock.git"
     outputs:
       changes: ${{ steps.git-check.outputs.changes-present }}
@@ -78,7 +78,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           include_diff: true
-          filterdiff_args: --include=**/assets/assets.json --include=**/src/web_accessible_resources/* --include=**/src/js/resources/* --include=**/src/js/redirect-resources.js --include=**/src/js/jsonpath.js --include=**/src/js/arglist-parser.js
+          filterdiff_args: --include=**/assets/assets.json --include=**/src/web_accessible_resources/* --include=**/src/js/resources/* --include=**/src/js/redirect-resources.js --include=**/src/js/jsonpath.js --include=**/src/js/arglist-parser.js --include=**/src/js/urlskip.js
   on-failure:
     runs-on: ubuntu-latest
     if: ${{ always() && (needs.sync.result == 'failure' || needs.create-pr.result == 'failure' || needs.update-pr.result == 'failure') }}

--- a/.github/workflows/sync-from-fork.yml
+++ b/.github/workflows/sync-from-fork.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     env:
-      FILES_TO_CHECK: "assets/assets.json|src/web_accessible_resources/|src/js/resources/|src/js/redirect-resources.js"
+      FILES_TO_CHECK: "assets/assets.json|src/web_accessible_resources/|src/js/resources/|src/js/redirect-resources.js|src/js/jsonpath.js|src/js/arglist-parser.js"
       UPSTREAM_URL: "https://github.com/gorhill/ublock.git"
     outputs:
       changes: ${{ steps.git-check.outputs.changes-present }}
@@ -78,7 +78,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           include_diff: true
-          filterdiff_args: --include=**/assets/assets.json --include=**/src/web_accessible_resources/* --include=**/src/js/resources/* --include=**/src/js/redirect-resources.js
+          filterdiff_args: --include=**/assets/assets.json --include=**/src/web_accessible_resources/* --include=**/src/js/resources/* --include=**/src/js/redirect-resources.js --include=**/src/js/jsonpath.js --include=**/src/js/arglist-parser.js
   on-failure:
     runs-on: ubuntu-latest
     if: ${{ always() && (needs.sync.result == 'failure' || needs.create-pr.result == 'failure' || needs.update-pr.result == 'failure') }}


### PR DESCRIPTION
These two files are imported from [`src/js/resources/shared.js`](https://github.com/brave/uBlock/blob/master/src/js/resources/shared.js), so they should also be captured by review.

This is becoming difficult to properly keep track of, so ideally we can move to a proper JS import tree parser in the future.