### PR TITLE
ci(sync): gate auto-PR on import scope verification

### DIFF
--- a/.github/braveCheckImports.js
+++ b/.github/braveCheckImports.js
@@ -1,0 +1,52 @@
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { registerHooks } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const loaded = new Set();
+
+registerHooks({
+  load(url, context, nextLoad) {
+    assert(url.startsWith("file:///"), `Remote URL blocked [${url}].`);
+    const filePath = fileURLToPath(url);
+    const relativePath = path.relative(process.cwd(), filePath);
+    const escaped = relativePath.startsWith("..") || path.isAbsolute(relativePath);
+    assert(!escaped, `Outside repo root [${relativePath}].`);
+    loaded.add(relativePath);
+    return nextLoad(url, context);
+  },
+});
+
+const { builtinScriptlets } = await import("../src/js/resources/scriptlets.js");
+assert(Array.isArray(builtinScriptlets), "scriptlets not an array.");
+
+const config = JSON.parse(fs.readFileSync(".github/pull-merge.json", "utf8"));
+const filterdiffArgs = config.filterdiff_args;
+assert(typeof filterdiffArgs === "string" && filterdiffArgs.length > 0,
+  ".github/pull-merge.json filterdiff_args missing/empty.");
+
+const syntheticDiff = [...loaded].map(p =>
+  `diff --git a/${p} b/${p}\n--- a/${p}\n+++ b/${p}\n@@ -0,0 +1 @@\n+x\n`
+).join("");
+
+const reviewed = await new Promise((resolve, reject) => {
+  const cp = spawn("filterdiff", ["--strip=1", "--list", ...filterdiffArgs.split(/\s+/).filter(Boolean)]);
+  const out = [], err = [];
+  cp.stdin.write(syntheticDiff);
+  cp.stdout.on("data", d => out.push(d));
+  cp.stderr.on("data", d => err.push(d));
+  cp.stdin.end();
+  cp.on("close", code => {
+    if (code !== 0) return reject(new Error(Buffer.concat(err).toString()));
+    resolve(new Set(Buffer.concat(out).toString().split("\n").filter(Boolean)));
+  });
+});
+
+const unreviewed = [...loaded].filter(p => !reviewed.has(p));
+assert(unreviewed.length === 0,
+  `Loaded but not in LLM review scope (filterdiff_args):\n${unreviewed.join("\n")}`);
+
+console.log(`Verified ${loaded.size} files against filterdiff_args. All in review scope.`);
+console.log("All checks succeeded.");

--- a/.github/workflows/sync-from-fork.yml
+++ b/.github/workflows/sync-from-fork.yml
@@ -47,12 +47,33 @@ jobs:
           git checkout -b mirror
           git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
           git push -u github mirror
+  check-imports:
+    permissions: {}
+    needs: sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: mirror
+          fetch-depth: 0
+      - name: Block if .github/pull-merge.json changed on mirror
+        run: |
+          git fetch origin master:refs/remotes/origin/master
+          if git diff --name-only origin/master..HEAD -- .github/pull-merge.json | grep -q .; then
+            echo "::error::.github/pull-merge.json modified by upstream sync — refusing to auto-merge."
+            exit 1
+          fi
+      - name: Install patchutils
+        run: sudo apt-get update && sudo apt-get install -y patchutils
+      - name: Run import checker (no network, no secrets)
+        run: sudo unshare -n node .github/braveCheckImports.js
   create-pr:
     permissions:
       pull-requests: write
+    if: ${{ needs.sync.result == 'success' && needs.check-imports.result == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    needs: sync
+    needs: [sync, check-imports]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -89,9 +110,10 @@ jobs:
           debug: "true"
   on-failure:
     runs-on: ubuntu-latest
-    if: ${{ always() && (needs.check-for-changes.result == 'failure' || needs.sync.result == 'failure' || needs.create-pr.result == 'failure' || needs.update-pr.result == 'failure') }}
+    if: ${{ always() && (needs.check-for-changes.result == 'failure' || needs.check-imports.result == 'failure' || needs.sync.result == 'failure' || needs.create-pr.result == 'failure' || needs.update-pr.result == 'failure') }}
     needs:
       - check-for-changes
+      - check-imports
       - sync
       - create-pr
       - update-pr

--- a/.github/workflows/test-sync-steps.yml
+++ b/.github/workflows/test-sync-steps.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test-sync-steps.yml
       - .github/actions/find-mirror-pr/**
       - .github/actions/create-or-skip-pr/**
+      - .github/braveCheckImports.js
 
 permissions:
   pull-requests: read
@@ -100,9 +101,20 @@ jobs:
         run: |
           echo "::group::On-failure condition validation"
           echo "Checking sync-from-fork.yml on-failure condition syntax:"
+          echo "  needs.check-imports.result == 'failure'"
           echo "  needs.check-for-changes.result == 'failure'"
           echo "  needs.sync.result == 'failure'"
           echo "  needs.create-pr.result == 'failure'"
           echo "  needs.update-pr.result == 'failure'"
           echo "All job names exist in the needs map."
           echo "::endgroup::"
+
+  test-check-imports:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install patchutils
+        run: sudo apt-get update && sudo apt-get install -y patchutils
+      - name: Run import checker (no network, no secrets)
+        run: sudo unshare -n node .github/braveCheckImports.js
+


### PR DESCRIPTION
New braveCheckImports.js validates all ESM imports from scriptlets.js
are covered by filterdiff_args in pull-merge.json. Runs in unshare -n
netns (no egress). Blocks create-pr unless check passes.

Tamper detection: fail if upstream sync modifies pull-merge.json.

test-sync-steps.yml mirrors the check for PR validation.