### PR TITLE
fix(sync): only block pull-merge.json when upstream adds or modifies it

### DIFF
--- a/.github/workflows/sync-from-fork.yml
+++ b/.github/workflows/sync-from-fork.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Block if .github/pull-merge.json changed on mirror
         run: |
           git fetch origin master:refs/remotes/origin/master
-          if git diff --name-only origin/master..HEAD -- .github/pull-merge.json | grep -q .; then
+          if git diff --name-only --diff-filter=AM origin/master..HEAD -- .github/pull-merge.json | grep -q .; then
             echo "::error::.github/pull-merge.json modified by upstream sync — refusing to auto-merge."
             exit 1
           fi


### PR DESCRIPTION
## Problem
The sync-from-fork workflow's "Block if .github/pull-merge.json changed on mirror" step always fails because:
1. `.github/pull-merge.json` exists in Brave's master but not in upstream (gorhill/uBlock)
2. `git diff --name-only origin/master..HEAD` shows the file as deleted
3. `grep -q .` matches any output, including deletion entries

Result: every scheduled sync run from this job gets blocked.

## Fix
Added `--diff-filter=AM` to the git diff command. This filters to only show files that were **A**dded or **M**odified in HEAD relative to origin/master. Deletions are excluded, so grep won't match when the file simply doesn't exist upstream.

## Verification
- `git diff --name-only HEAD..upstream/master -- .github/pull-merge.json` → shows file with status D (deleted)
- `git diff --name-only --diff-filter=AM HEAD..upstream/master -- .github/pull-merge.json` → no output