### PR TITLE
fix(sync): restore Brave files before running import checker

### DIFF
--- a/.github/workflows/sync-from-fork.yml
+++ b/.github/workflows/sync-from-fork.yml
@@ -66,7 +66,9 @@ jobs:
       - name: Install patchutils
         run: sudo apt-get update && sudo apt-get install -y patchutils
       - name: Run import checker (no network, no secrets)
-        run: sudo unshare -n node .github/braveCheckImports.js
+        run: |
+          git checkout origin/master -- .github/braveCheckImports.js .github/pull-merge.json
+          sudo unshare -n node .github/braveCheckImports.js
   create-pr:
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Problem
The check-imports job checks out the mirror branch (clone of upstream gorhill/uBlock), which does not contain Brave-specific files:
- .github/braveCheckImports.js
- .github/pull-merge.json

Node fails with: Error: Cannot find module '/home/runner/work/uBlock/uBlock/.github/braveCheckImports.js'

Example failure: https://github.com/brave/uBlock/actions/runs/28986087912/job/86015475128

## Fix
Before running node .github/braveCheckImports.js, restore the Brave-specific files from origin/master using git checkout.