### PR TITLE
Improve sync-from-fork CI error message and tag on Slack

### DIFF
--- a/.github/workflows/sync-from-fork.yml
+++ b/.github/workflows/sync-from-fork.yml
@@ -127,3 +127,4 @@ jobs:
           author_name: "Github Actions"
           status: failure
           fields: repo,message,commit,author,eventName,ref,workflow,pullRequest
+          text: "<!subteam^${{ secrets.UBO_SYNC_REVIEWERS_SLACK_GROUP_ID }}> Sync from fork failed for ${{ github.repository }}. Check the failed run and re-run or fix as needed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/sync-from-fork.yml
+++ b/.github/workflows/sync-from-fork.yml
@@ -120,6 +120,16 @@ jobs:
       - create-pr
       - update-pr
     steps:
+      - name: Identify failed job
+        id: failed
+        run: |
+          if [ "${{ needs.check-for-changes.result }}" = "failure" ]; then job=check-for-changes
+          elif [ "${{ needs.sync.result }}" = "failure" ]; then job=sync
+          elif [ "${{ needs.check-imports.result }}" = "failure" ]; then job=check-imports
+          elif [ "${{ needs.create-pr.result }}" = "failure" ]; then job=create-pr
+          elif [ "${{ needs.update-pr.result }}" = "failure" ]; then job=update-pr
+          fi
+          echo "job=$job" >> "$GITHUB_OUTPUT"
       - uses: 8398a7/action-slack@28ba43ae48961b90635b50953d216767a6bea486 # v3.16.2
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -127,4 +137,4 @@ jobs:
           author_name: "Github Actions"
           status: failure
           fields: repo,message,commit,author,eventName,ref,workflow,pullRequest
-          text: "<!subteam^${{ secrets.UBO_SYNC_REVIEWERS_SLACK_GROUP_ID }}> Sync from fork failed for ${{ github.repository }}. Check the failed run and re-run or fix as needed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          text: "<!subteam^${{ secrets.UBO_SYNC_REVIEWERS_SLACK_GROUP_ID }}> Sync from fork failed for ${{ github.repository }} (failed job: ${{ steps.failed.outputs.job }}). Check the failed run and re-run or fix as needed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
- Tags the reviewer group on Slack
- Names the failed job (e.g. create-pr), not just "workflow failed"
- Direct link to the failed run for one-click access to logs

On Slack, this would look something like:

```
webhook for extensions-bot channel  APP

@ubo-sync-reviewers Sync from fork failed for brave/uBlock
(failed job: create-pr). Check the failed run and re-run or
fix as needed: https://github.com/brave/uBlock/actions/runs/1234567890

⛔ Failed GitHub Actions
┃ Github Actions
┃ repo              message
┃ brave/uBlock      Merge pull request #324 from brave/mirror
┃ commit            author
┃ e0caa496          Andrea<xyz@users.noreply.github.com>
┃ eventName         ref
┃ schedule          refs/heads/master
┃ workflow          pullRequest
┃ Sync from fork    n/a
```