### PR TITLE
chore(sync): sanitize .github/ from mirror commits via rebase

### DIFF
--- a/.github/sync_mirror.sh
+++ b/.github/sync_mirror.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Sync gorhill/uBlock -> brave/uBlock `mirror` branch.
+#
+# Used by:
+#   - .github/workflows/sync-from-fork.yml (automated, hourly cron)
+#   - admins locally as a break-glass when the automated push is blocked.
+#
+# Sanitization: any new upstream commit's changes under .github/ are stripped
+# before pushing. GitHub refuses pushes via GITHUB_TOKEN that modify files under
+# .github/workflows/* without the `workflows` permission, and granting that
+# scope would allow workflow edits -> secret exfiltration. By rebasing the new
+# upstream commits onto the existing origin/mirror and amending each one to
+# restore .github/ from its parent, the pushed commit range contains zero
+# .github/ modifications, so the push is permitted and no upstream .github/
+# changes flow into the master<-mirror merge (which is what previously required
+# per-sync manual conflict resolution).
+set -euo pipefail
+
+REMOTE_UPSTREAM="${REMOTE_UPSTREAM:-upstream}"
+REMOTE_ORIGIN="${REMOTE_ORIGIN:-origin}"
+UPSTREAM_URL="${UPSTREAM_URL:-https://github.com/gorhill/uBlock.git}"
+ORIGIN_URL="${ORIGIN_URL:-https://github.com/brave/uBlock.git}"
+BRANCH_SRC="${BRANCH_SRC:-master}"
+BRANCH_MIRROR="${BRANCH_MIRROR:-mirror}"
+SANITIZE="${SANITIZE:-1}"
+
+ensure_remote() {
+  local name="$1" url="$2"
+  if ! git remote get-url "$name" >/dev/null 2>&1; then
+    echo "Remote '${name}' missing. Adding ${url}..."
+    git remote add "$name" "$url"
+  fi
+}
+
+# `git commit --amend` during rebase needs an identity. Set a local fallback
+# only if none is configured (never touches global/user-supplied config).
+if ! git config user.email >/dev/null 2>&1; then
+  git config user.email "sync-mirror@local"
+fi
+if ! git config user.name >/dev/null 2>&1; then
+  git config user.name "sync_mirror.sh"
+fi
+
+ensure_remote "$REMOTE_UPSTREAM" "$UPSTREAM_URL"
+ensure_remote "$REMOTE_ORIGIN" "$ORIGIN_URL"
+
+echo "Fetching ${REMOTE_UPSTREAM}/${BRANCH_SRC}..."
+git fetch "$REMOTE_UPSTREAM" "${BRANCH_SRC}:refs/remotes/${REMOTE_UPSTREAM}/${BRANCH_SRC}"
+
+echo "Checking for existing ${BRANCH_MIRROR} on ${REMOTE_ORIGIN}..."
+if git ls-remote --exit-code "$REMOTE_ORIGIN" "$BRANCH_MIRROR" >/dev/null 2>&1; then
+  git fetch "$REMOTE_ORIGIN" "${BRANCH_MIRROR}:refs/remotes/${REMOTE_ORIGIN}/${BRANCH_MIRROR}"
+  HAVE_MIRROR=1
+else
+  echo "No existing ${BRANCH_MIRROR} on ${REMOTE_ORIGIN}; bootstrapping."
+  HAVE_MIRROR=0
+fi
+
+echo "Pointing local ${BRANCH_MIRROR} at ${REMOTE_UPSTREAM}/${BRANCH_SRC}..."
+git checkout -B "$BRANCH_MIRROR" "refs/remotes/${REMOTE_UPSTREAM}/${BRANCH_SRC}"
+
+if [ "$SANITIZE" = "1" ] && [ "$HAVE_MIRROR" = "1" ]; then
+  base="refs/remotes/${REMOTE_ORIGIN}/${BRANCH_MIRROR}"
+  echo "Sanitizing .github/ out of new commits (rebase onto ${base})..."
+  # Replays only (base..HEAD) = new upstream commits onto the existing mirror
+  # tip. For each replayed commit, restore .github/ from its parent and amend,
+  # so the commit carries no .github/ diff. --keep-empty preserves commits that
+  # become empty (upstream .github-only changes).
+  git rebase "$base" --keep-empty \
+    --exec 'git restore --source=HEAD^ --staged --worktree -- .github/ && git commit --amend --no-edit --allow-empty'
+elif [ "$SANITIZE" = "1" ]; then
+  echo "Bootstrap: no prior mirror to rebase against; skipping sanitize of full history."
+fi
+
+echo "Pushing ${BRANCH_MIRROR} to ${REMOTE_ORIGIN}..."
+if [ "$HAVE_MIRROR" = "1" ]; then
+  # Rebased commits have new SHAs -> non-ff; --force-with-lease guards against
+  # concurrent pushes.
+  git push "$REMOTE_ORIGIN" "${BRANCH_MIRROR}:refs/heads/${BRANCH_MIRROR}" --force-with-lease="refs/heads/${BRANCH_MIRROR}:refs/remotes/${REMOTE_ORIGIN}/${BRANCH_MIRROR}"
+else
+  git push "$REMOTE_ORIGIN" "${BRANCH_MIRROR}:refs/heads/${BRANCH_MIRROR}"
+fi
+
+echo "Done. $(git log --oneline -1 "$BRANCH_MIRROR")"

--- a/.github/workflows/sync-from-fork.yml
+++ b/.github/workflows/sync-from-fork.yml
@@ -2,7 +2,7 @@ name: Sync from fork
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: "0 * * * *"
+    - cron: "0 */3 * * *"
   workflow_dispatch:
 
 permissions: {}
@@ -40,13 +40,22 @@ jobs:
     needs: check-for-changes
     runs-on: ubuntu-latest
     steps:
-      - name: Create mirror branch
+      - name: Clone Brave fork (provides .github/sync_mirror.sh)
         run: |
-          git clone "https://github.com/gorhill/${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}"
-          cd ${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}
-          git checkout -b mirror
-          git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
-          git push -u github mirror
+          git clone "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" repo
+          cd repo
+          git remote add upstream https://github.com/gorhill/uBlock.git
+      - name: Sync mirror (sanitize .github/ from upstream commits)
+        working-directory: repo
+        env:
+          REMOTE_UPSTREAM: upstream
+          REMOTE_ORIGIN: origin
+          UPSTREAM_URL: https://github.com/gorhill/uBlock.git
+          ORIGIN_URL: https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/${{ github.repository }}.git
+          BRANCH_SRC: master
+          BRANCH_MIRROR: mirror
+          SANITIZE: "1"
+        run: bash .github/sync_mirror.sh
   check-imports:
     permissions: {}
     needs: sync

--- a/.github/workflows/test-sync-steps.yml
+++ b/.github/workflows/test-sync-steps.yml
@@ -8,6 +8,7 @@ on:
       - .github/actions/find-mirror-pr/**
       - .github/actions/create-or-skip-pr/**
       - .github/braveCheckImports.js
+      - .github/sync_mirror.sh
 
 permissions:
   pull-requests: read
@@ -117,4 +118,75 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y patchutils
       - name: Run import checker (no network, no secrets)
         run: sudo unshare -n node .github/braveCheckImports.js
+
+  test-sync-sanitize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Exercise sync_mirror.sh sanitize against temp repos
+        run: |
+          set -euo pipefail
+          ROOT="$(mktemp -d)"
+          UPSTREAM="${ROOT}/upstream"
+          ORIGIN="${ROOT}/origin.git"
+          WORK="${ROOT}/work"
+
+          # Bare origin (push target).
+          git init --bare -b mirror "$ORIGIN"
+
+          # Seed upstream: base commit with .github/workflows/w.yml + code.txt.
+          git init -b master "$UPSTREAM"
+          git -C "$UPSTREAM" config user.email t@t
+          git -C "$UPSTREAM" config user.name t
+          mkdir -p "$UPSTREAM/.github/workflows"
+          printf 'name: w\non: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps: [{run: echo hi}]\n' > "$UPSTREAM/.github/workflows/w.yml"
+          printf 'base\n' > "$UPSTREAM/code.txt"
+          git -C "$UPSTREAM" add -A
+          git -C "$UPSTREAM" commit -m "base: add workflow + code"
+
+          # Bootstrap origin/mirror from upstream base.
+          git -C "$UPSTREAM" remote add origin "$ORIGIN"
+          git -C "$UPSTREAM" push origin master:mirror
+
+          # New upstream commit: modify BOTH .github/workflows/w.yml and code.txt.
+          printf 'name: w2\non: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps: [{run: echo bye}]\n' > "$UPSTREAM/.github/workflows/w.yml"
+          printf 'base\nnew-upstream-change\n' > "$UPSTREAM/code.txt"
+          git -C "$UPSTREAM" add -A
+          git -C "$UPSTREAM" commit -m "upstream: edit workflow + code"
+
+          # Run the script from a separate working clone (like CI does).
+          git clone "$UPSTREAM" "$WORK"
+          git -C "$WORK" remote set-url origin "$ORIGIN"
+
+          # Copy the script under test into $WORK so it runs against the temp
+          # remotes, not the brave/uBlock checkout's real `upstream` remote.
+          mkdir -p "$WORK/.github"
+          cp .github/sync_mirror.sh "$WORK/.github/sync_mirror.sh"
+
+          pushd "$WORK" >/dev/null
+          REMOTE_UPSTREAM=upstream REMOTE_ORIGIN=origin \
+            UPSTREAM_URL="$UPSTREAM" ORIGIN_URL="$ORIGIN" \
+            BRANCH_SRC=master BRANCH_MIRROR=mirror SANITIZE=1 \
+            bash .github/sync_mirror.sh
+          popd >/dev/null
+
+          # Verify pushed mirror: code change present, workflow change absent.
+          git clone "$ORIGIN" "${WORK}-verify"
+          pushd "${WORK}-verify" >/dev/null
+          if ! grep -q 'new-upstream-change' code.txt; then
+            echo "FAIL: code.txt change missing from mirror"; exit 1
+          fi
+          if ! grep -q '^name: w$' .github/workflows/w.yml; then
+            echo "FAIL: upstream workflow change leaked into mirror"; exit 1
+          fi
+          # Mirror tip must be a descendant of the bootstrap commit, and the
+          # new upstream commit must NOT be reachable verbatim (it was amended).
+          base_sha="$(git rev-parse HEAD~1 || true)"
+          if git log --format=%H | grep -q "$(git -C "$UPSTREAM" rev-parse master)"; then
+            echo "FAIL: unsanitized upstream commit reachable from mirror"; exit 1
+          fi
+          popd >/dev/null
+
+          echo "PASS: sanitize strips .github/ changes, preserves code changes."
+
 


### PR DESCRIPTION
## Problem

GitHub rejects `GITHUB_TOKEN` pushes that modify `.github/workflows/*` without the `workflows` permission. Granting that scope would allow a workflow edit to exfiltrate secrets, so the automated sync push from `gorhill/uBlock` -> `brave/uBlock` `mirror` branch is blocked whenever the upstream commit range touches `.github/workflows/*` (e.g. the 2026-08-15 failure on `main.yml`). Admins then have to run a local break-glass push.

Previously each `master <- mirror` merge also hit `.github/` conflicts that had to be resolved manually (re-adding Brave-only files), because the upstream commits in the pushed range carried `.github/` diffs.

## Fix

Add `.github/sync_mirror.sh` (unifies CI + admin break-glass, supersedes #329):

1. Fetch `upstream/master` and `origin/mirror`.
2. `git checkout -B mirror refs/remotes/upstream/master`.
3. If `origin/mirror` exists, rebase the new commits `(origin/mirror..upstream/master)` onto `origin/mirror` with `--keep-empty --exec 'git restore --source=HEAD^ --staged --worktree -- .github/ && git commit --amend --no-edit --allow-empty'` — each replayed commit is amended to restore `.github/` from its parent, so it carries no `.github/` diff. Code changes flow through unchanged; upstream-only `.github/` changes become empty commits that are preserved via `--keep-empty`.
4. Push `mirror` `--force-with-lease` (rebased commits get new SHAs).

Effect: the pushed commit range contains zero `.github/` modifications, so the `GITHUB_TOKEN` push is permitted, and `master <- mirror` merges no longer hit `.github/` conflicts.

`sync-from-fork.yml` `sync` job: now clones `brave/uBlock` (which ships the script), adds the `upstream` remote, and runs `sync_mirror.sh` with `ORIGIN_URL=https://$ACTOR:$TOKEN@github.com/$REPO.git`.

## Tests

`test-sync-steps.yml`:
- Add `.github/sync_mirror.sh` to trigger paths.
- New `test-sync-sanitize` job builds temp upstream/origin bare repos, seeds `origin/mirror`, makes an upstream commit touching both `.github/workflows/w.yml` and `code.txt`, runs the script, and asserts: `code.txt` change present, `w.yml` unchanged, and the unsanitized upstream commit unreachable from the pushed mirror. The `--allow-empty` path covers workflow-only upstream commits.

Validated locally against temp repos: both the mixed-change and workflow-only scenarios pass; bootstrap (no existing mirror) also passes.

## No deletion commit

Audited all five Brave workflows: `assign-pr`, `check-release-merged`, `main`, `sync-from-fork`, `test-sync-steps` — all are enabled. `RELEASE.HEAD.md` is consumed by `main.yml` (Brave actively patches `main.yml` to use `softprops/action-gh-release@v2`), and `ISSUE_TEMPLATE/config.yml` gates issue UX. No upstream-only enabled-workflow files exist to delete, so sanitize alone is sufficient.

## Supersedes #329

Closes #329.