### PR TITLE
fix(ci): sanitize .github from mirror sync commits

### DIFF
--- a/.github/sync_mirror.sh
+++ b/.github/sync_mirror.sh
@@ -2,18 +2,22 @@
 # Sync gorhill/uBlock -> brave/uBlock `mirror` branch.
 #
 # Used by:
-#   - .github/workflows/sync-from-fork.yml (automated, hourly cron)
+#   - .github/workflows/sync-from-fork.yml (automated, cron)
 #   - admins locally as a break-glass when the automated push is blocked.
 #
-# Sanitization: any new upstream commit's changes under .github/ are stripped
-# before pushing. GitHub refuses pushes via GITHUB_TOKEN that modify files under
-# .github/workflows/* without the `workflows` permission, and granting that
-# scope would allow workflow edits -> secret exfiltration. By rebasing the new
-# upstream commits onto the existing origin/mirror and amending each one to
-# restore .github/ from its parent, the pushed commit range contains zero
-# .github/ modifications, so the push is permitted and no upstream .github/
-# changes flow into the master<-mirror merge (which is what previously required
-# per-sync manual conflict resolution).
+# Strategy: the mirror branch is origin/master plus ONE squashed "Sync
+# upstream" commit per run:
+#   - parent  = current origin/master tip
+#   - tree    = upstream tree, with .github/ replaced by origin/master's and
+#               Brave-only files (on master, not upstream) carried over
+#   - the commit message records the synced upstream SHA
+#
+# The sync commit never modifies .github/ relative to its parent, so a
+# GITHUB_TOKEN push (which lacks the `workflows` permission) is always
+# accepted: GitHub only rejects pushes whose *new* commits touch workflow
+# files. It also keeps the master<-mirror merge free of .github/ conflicts.
+# If the mirror branch is deleted (e.g. auto-delete after PR merge), the next
+# run recreates it from the current master tip, so the sync is self-healing.
 set -euo pipefail
 
 REMOTE_UPSTREAM="${REMOTE_UPSTREAM:-upstream}"
@@ -24,6 +28,10 @@ BRANCH_SRC="${BRANCH_SRC:-master}"
 BRANCH_MIRROR="${BRANCH_MIRROR:-mirror}"
 SANITIZE="${SANITIZE:-1}"
 
+# Deterministic byte-wise sorting: git ls-tree output order must match `sort`
+# order for the `comm` set operations below, independent of runner locale.
+export LC_ALL=C
+
 ensure_remote() {
   local name="$1" url="$2"
   if ! git remote get-url "$name" >/dev/null 2>&1; then
@@ -32,8 +40,8 @@ ensure_remote() {
   fi
 }
 
-# `git commit --amend` during rebase needs an identity. Set a local fallback
-# only if none is configured (never touches global/user-supplied config).
+# `git commit-tree` needs an identity. Set a local fallback only if none is
+# configured (never touches global/user-supplied config).
 if ! git config user.email >/dev/null 2>&1; then
   git config user.email "sync-mirror@local"
 fi
@@ -45,40 +53,103 @@ ensure_remote "$REMOTE_UPSTREAM" "$UPSTREAM_URL"
 ensure_remote "$REMOTE_ORIGIN" "$ORIGIN_URL"
 
 echo "Fetching ${REMOTE_UPSTREAM}/${BRANCH_SRC}..."
-git fetch "$REMOTE_UPSTREAM" "${BRANCH_SRC}:refs/remotes/${REMOTE_UPSTREAM}/${BRANCH_SRC}"
+git fetch "$REMOTE_UPSTREAM" "+${BRANCH_SRC}:refs/remotes/${REMOTE_UPSTREAM}/${BRANCH_SRC}"
+echo "Fetching ${REMOTE_ORIGIN}/${BRANCH_SRC}..."
+git fetch "$REMOTE_ORIGIN" "+${BRANCH_SRC}:refs/remotes/${REMOTE_ORIGIN}/${BRANCH_SRC}"
+
+UP="$(git rev-parse "refs/remotes/${REMOTE_UPSTREAM}/${BRANCH_SRC}")"
+M="$(git rev-parse "refs/remotes/${REMOTE_ORIGIN}/${BRANCH_SRC}")"
 
 echo "Checking for existing ${BRANCH_MIRROR} on ${REMOTE_ORIGIN}..."
-if git ls-remote --exit-code "$REMOTE_ORIGIN" "$BRANCH_MIRROR" >/dev/null 2>&1; then
+OLD="$(git ls-remote "$REMOTE_ORIGIN" "refs/heads/${BRANCH_MIRROR}" | awk '{print $1}')"
+if [ -n "$OLD" ]; then
   git fetch "$REMOTE_ORIGIN" "${BRANCH_MIRROR}:refs/remotes/${REMOTE_ORIGIN}/${BRANCH_MIRROR}"
-  HAVE_MIRROR=1
+  echo "Existing mirror at ${OLD}."
 else
-  echo "No existing ${BRANCH_MIRROR} on ${REMOTE_ORIGIN}; bootstrapping."
-  HAVE_MIRROR=0
+  echo "No existing ${BRANCH_MIRROR} on ${REMOTE_ORIGIN}; bootstrapping from current ${REMOTE_ORIGIN}/${BRANCH_SRC}."
 fi
 
-echo "Pointing local ${BRANCH_MIRROR} at ${REMOTE_UPSTREAM}/${BRANCH_SRC}..."
-git checkout -B "$BRANCH_MIRROR" "refs/remotes/${REMOTE_UPSTREAM}/${BRANCH_SRC}"
+push_mirror() {
+  local ref="$1"
+  if [ -n "$OLD" ]; then
+    # Replaces the previous sync commit (often non-ff); --force-with-lease
+    # guards against concurrent pushes.
+    git push "$REMOTE_ORIGIN" "${ref}:refs/heads/${BRANCH_MIRROR}" \
+      --force-with-lease="refs/heads/${BRANCH_MIRROR}:${OLD}"
+  else
+    git push "$REMOTE_ORIGIN" "${ref}:refs/heads/${BRANCH_MIRROR}"
+  fi
+}
 
-if [ "$SANITIZE" = "1" ] && [ "$HAVE_MIRROR" = "1" ]; then
-  base="refs/remotes/${REMOTE_ORIGIN}/${BRANCH_MIRROR}"
-  echo "Sanitizing .github/ out of new commits (rebase onto ${base})..."
-  # Replays only (base..HEAD) = new upstream commits onto the existing mirror
-  # tip. For each replayed commit, restore .github/ from its parent and amend,
-  # so the commit carries no .github/ diff. --keep-empty preserves commits that
-  # become empty (upstream .github-only changes).
-  git rebase "$base" --keep-empty \
-    --exec 'git restore --source=HEAD^ --staged --worktree -- .github/ && git commit --amend --no-edit --allow-empty'
-elif [ "$SANITIZE" = "1" ]; then
-  echo "Bootstrap: no prior mirror to rebase against; skipping sanitize of full history."
+if [ "$SANITIZE" != "1" ]; then
+  echo "SANITIZE=0: mirroring ${REMOTE_UPSTREAM}/${BRANCH_SRC} verbatim (break-glass; workflow files may get rejected)."
+  push_mirror "$UP"
+  echo "Done. mirror = ${UP}"
+  exit 0
 fi
+
+# Upstream SHA recorded by the previous sync commit; used to honor upstream
+# deletions (a file present at the last synced upstream but gone now must not
+# be carried back from master).
+UP_PREV=""
+if [ -n "$OLD" ]; then
+  UP_PREV="$(git log -1 --format=%B "refs/remotes/${REMOTE_ORIGIN}/${BRANCH_MIRROR}" \
+    | grep -om1 -E '[0-9a-f]{40}' || true)"
+  if [ -n "$UP_PREV" ] && ! git cat-file -e "$UP_PREV^{commit}" 2>/dev/null; then
+    echo "WARN: recorded upstream SHA ${UP_PREV} not present locally; ignoring."
+    UP_PREV=""
+  fi
+  if [ -z "$UP_PREV" ]; then
+    echo "WARN: no upstream SHA found in previous mirror commit ${OLD}; upstream deletions may be resurrected this run."
+  fi
+fi
+
+TMPDIR_SYNC="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_SYNC"' EXIT
+export GIT_INDEX_FILE="${TMPDIR_SYNC}/index"
+
+# Build the sanitized sync tree in a temporary index (no worktree needed):
+# upstream tree, with .github/ swapped for master's and Brave-only files kept.
+git read-tree "$UP"
+git rm -rfq --cached --ignore-unmatch .github
+if git cat-file -e "${M}:.github" 2>/dev/null; then
+  git read-tree --prefix .github/ "${M}:.github"
+fi
+
+# Brave-only files: on master, absent upstream, not under .github/. Files that
+# upstream deleted since the last sync are NOT carried (they must go away).
+git ls-tree -r --name-only "$M" | sort > "${TMPDIR_SYNC}/master.lst"
+git ls-tree -r --name-only "$UP" | sort > "${TMPDIR_SYNC}/upstream.lst"
+comm -23 "${TMPDIR_SYNC}/master.lst" "${TMPDIR_SYNC}/upstream.lst" \
+  | grep -v '^\.github/' > "${TMPDIR_SYNC}/carry.lst" || true
+if [ -n "$UP_PREV" ] && [ -s "${TMPDIR_SYNC}/carry.lst" ]; then
+  git ls-tree -r --name-only "$UP_PREV" | sort > "${TMPDIR_SYNC}/upstream-prev.lst"
+  comm -23 "${TMPDIR_SYNC}/carry.lst" "${TMPDIR_SYNC}/upstream-prev.lst" \
+    > "${TMPDIR_SYNC}/carry.tmp" && mv "${TMPDIR_SYNC}/carry.tmp" "${TMPDIR_SYNC}/carry.lst"
+fi
+if [ -s "${TMPDIR_SYNC}/carry.lst" ]; then
+  echo "Carrying Brave-only files: $(wc -l < "${TMPDIR_SYNC}/carry.lst") file(s)."
+  while IFS= read -r path; do
+    git ls-tree "$M" -- "$path" | git update-index --index-info
+  done < "${TMPDIR_SYNC}/carry.lst"
+fi
+
+TREE="$(git write-tree)"
+if [ "$TREE" = "$(git rev-parse "${M}^{tree}")" ]; then
+  echo "No changes to sync (upstream matches master after sanitize). Nothing to push."
+  exit 0
+fi
+if [ -n "$OLD" ] && [ "$TREE" = "$(git rev-parse "${OLD}^{tree}")" ]; then
+  echo "No changes to sync (mirror already carries this upstream tree). Nothing to push."
+  exit 0
+fi
+
+# Full upstream SHA in the message doubles as the UP_PREV marker parsed above.
+COMMIT="$(git commit-tree "$TREE" -p "$M" -m "Sync upstream gorhill/uBlock at ${UP}")"
+echo "Created sync commit ${COMMIT} (upstream ${UP})."
+unset GIT_INDEX_FILE
 
 echo "Pushing ${BRANCH_MIRROR} to ${REMOTE_ORIGIN}..."
-if [ "$HAVE_MIRROR" = "1" ]; then
-  # Rebased commits have new SHAs -> non-ff; --force-with-lease guards against
-  # concurrent pushes.
-  git push "$REMOTE_ORIGIN" "${BRANCH_MIRROR}:refs/heads/${BRANCH_MIRROR}" --force-with-lease="refs/heads/${BRANCH_MIRROR}:refs/remotes/${REMOTE_ORIGIN}/${BRANCH_MIRROR}"
-else
-  git push "$REMOTE_ORIGIN" "${BRANCH_MIRROR}:refs/heads/${BRANCH_MIRROR}"
-fi
+push_mirror "$COMMIT"
 
-echo "Done. $(git log --oneline -1 "$BRANCH_MIRROR")"
+echo "Done. mirror = ${COMMIT}"

--- a/.github/workflows/test-sync-steps.yml
+++ b/.github/workflows/test-sync-steps.yml
@@ -131,62 +131,116 @@ jobs:
           ORIGIN="${ROOT}/origin.git"
           WORK="${ROOT}/work"
 
-          # Bare origin (push target).
-          git init --bare -b mirror "$ORIGIN"
+          # Bare origin (push target). master = Brave master; no mirror yet.
+          git init --bare -q "$ORIGIN"
 
-          # Seed upstream: base commit with .github/workflows/w.yml + code.txt.
-          git init -b master "$UPSTREAM"
+          # Seed upstream: base commit with .github (workflow + nested file) and code files.
+          git init -q -b master "$UPSTREAM"
           git -C "$UPSTREAM" config user.email t@t
           git -C "$UPSTREAM" config user.name t
-          mkdir -p "$UPSTREAM/.github/workflows"
+          mkdir -p "$UPSTREAM/.github/workflows" "$UPSTREAM/.github/nested/deep"
           printf 'name: w\non: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps: [{run: echo hi}]\n' > "$UPSTREAM/.github/workflows/w.yml"
+          printf 'nested\n' > "$UPSTREAM/.github/nested/deep/file.txt"
           printf 'base\n' > "$UPSTREAM/code.txt"
+          printf 'to-be-deleted\n' > "$UPSTREAM/code2.txt"
           git -C "$UPSTREAM" add -A
-          git -C "$UPSTREAM" commit -m "base: add workflow + code"
+          git -C "$UPSTREAM" commit -qm "base: add workflow + code"
 
-          # Bootstrap origin/mirror from upstream base.
+          # Seed origin master from upstream base (mimics brave master state).
           git -C "$UPSTREAM" remote add origin "$ORIGIN"
-          git -C "$UPSTREAM" push origin master:mirror
+          git -C "$UPSTREAM" push -q origin master:master
 
-          # New upstream commit: modify BOTH .github/workflows/w.yml and code.txt.
+          # Upstream commit 2: touch BOTH .github (modify, add, delete at multiple depths) AND code files.
           printf 'name: w2\non: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps: [{run: echo bye}]\n' > "$UPSTREAM/.github/workflows/w.yml"
+          printf 'brand new workflow\n' > "$UPSTREAM/.github/workflows/new.yml"
+          rm "$UPSTREAM/.github/nested/deep/file.txt"
           printf 'base\nnew-upstream-change\n' > "$UPSTREAM/code.txt"
           git -C "$UPSTREAM" add -A
-          git -C "$UPSTREAM" commit -m "upstream: edit workflow + code"
+          git -C "$UPSTREAM" commit -qm "upstream: edit workflow + code"
+          UP_SHA="$(git -C "$UPSTREAM" rev-parse master)"
 
           # Run the script from a separate working clone (like CI does).
-          git clone "$UPSTREAM" "$WORK"
+          git clone -q "$UPSTREAM" "$WORK"
           git -C "$WORK" remote set-url origin "$ORIGIN"
+          git -C "$WORK" remote add upstream "$UPSTREAM"
 
-          # Copy the script under test into $WORK so it runs against the temp
-          # remotes, not the brave/uBlock checkout's real `upstream` remote.
-          mkdir -p "$WORK/.github"
-          cp .github/sync_mirror.sh "$WORK/.github/sync_mirror.sh"
+          cp "${GITHUB_WORKSPACE:-$PWD}/.github/sync_mirror.sh" "$WORK/sync_mirror.sh"
 
-          pushd "$WORK" >/dev/null
-          REMOTE_UPSTREAM=upstream REMOTE_ORIGIN=origin \
+          run_sync() { (cd "$WORK" && env REMOTE_UPSTREAM=upstream REMOTE_ORIGIN=origin \
             UPSTREAM_URL="$UPSTREAM" ORIGIN_URL="$ORIGIN" \
             BRANCH_SRC=master BRANCH_MIRROR=mirror SANITIZE=1 \
-            bash .github/sync_mirror.sh
-          popd >/dev/null
+            bash sync_mirror.sh) > "${ROOT}/last.log" 2>&1 \
+            || { cat "${ROOT}/last.log"; exit 1; }; }
 
-          # Verify pushed mirror: code change present, workflow change absent.
-          git clone "$ORIGIN" "${WORK}-verify"
-          pushd "${WORK}-verify" >/dev/null
-          if ! grep -q 'new-upstream-change' code.txt; then
-            echo "FAIL: code.txt change missing from mirror"; exit 1
-          fi
-          if ! grep -q '^name: w$' .github/workflows/w.yml; then
-            echo "FAIL: upstream workflow change leaked into mirror"; exit 1
-          fi
-          # Mirror tip must be a descendant of the bootstrap commit, and the
-          # new upstream commit must NOT be reachable verbatim (it was amended).
-          base_sha="$(git rev-parse HEAD~1 || true)"
-          if git log --format=%H | grep -q "$(git -C "$UPSTREAM" rev-parse master)"; then
+          # Verify-clone helpers: refresh local mirror ref, assert .github/ untouched.
+          sync_verify() {
+            cd "$V"
+            git fetch -q origin mirror && git checkout -q mirror && git reset -q --hard FETCH_HEAD
+          }
+          assert_github_untouched() {
+            if git diff --name-only master..mirror -- .github/ | grep -q .; then
+              echo "FAIL: mirror sync commit modifies .github/"; exit 1
+            fi
+          }
+
+          # --- 1. Bootstrap run (no mirror on origin yet). ---
+          run_sync
+          git clone -q -c user.email=t@t -c user.name=t "$ORIGIN" "${WORK}-verify"
+          V="${WORK}-verify"
+          sync_verify
+          grep -q 'new-upstream-change' code.txt
+          grep -q '^name: w$' .github/workflows/w.yml
+          test ! -e .github/workflows/new.yml
+          test -e .github/nested/deep/file.txt
+          assert_github_untouched
+          if git log --format=%H mirror | grep -q "$UP_SHA"; then
             echo "FAIL: unsanitized upstream commit reachable from mirror"; exit 1
           fi
-          popd >/dev/null
+          test "$(git rev-parse mirror^)" = "$(git rev-parse master)"
+          echo "SCENARIO 1 (bootstrap, mixed change): PASS"
+          cd "$ROOT"
 
-          echo "PASS: sanitize strips .github/ changes, preserves code changes."
+          # --- 2. Upstream .github-only change -> nothing to push. ---
+          printf 'workflow-only change\n' >> "$UPSTREAM/.github/workflows/w.yml"
+          git -C "$UPSTREAM" add -A
+          git -C "$UPSTREAM" commit -qm "upstream: workflow-only"
+          OLD_MIRROR="$(git -C "$V" rev-parse mirror)"
+          run_sync
+          grep -q "Nothing to push" "${ROOT}/last.log"
+          test "$OLD_MIRROR" = "$(git ls-remote "$ORIGIN" refs/heads/mirror | awk '{print $1}')"
+          echo "SCENARIO 2 (workflow-only -> no-op): PASS"
 
+          # --- 3. Incremental run + upstream deletion honored. ---
+          printf 'base\nnew-upstream-change\nthird\n' > "$UPSTREAM/code.txt"
+          rm "$UPSTREAM/code2.txt"
+          git -C "$UPSTREAM" add -A
+          git -C "$UPSTREAM" commit -qm "upstream: more code, delete code2"
+          run_sync
+          sync_verify
+          grep -q 'third' code.txt
+          test ! -e code2.txt
+          assert_github_untouched
+          echo "SCENARIO 3 (incremental + deletion): PASS"
+          cd "$ROOT"
 
+          # --- 4. Self-healing: deleted mirror is recreated. ---
+          git -C "$WORK" push -q origin --delete mirror
+          run_sync
+          test -n "$(git ls-remote "$ORIGIN" refs/heads/mirror)"
+          sync_verify
+          grep -q 'third' code.txt
+          echo "SCENARIO 4 (self-heal recreate): PASS"
+
+          # --- 5. Brave-only file carry (non-.github). ---
+          printf 'brave-only\n' > "$V/brave_only.txt"
+          git -C "$V" checkout -q master
+          git -C "$V" add -A && git -C "$V" commit -qm "brave: add brave-only file" && git -C "$V" push -q origin master:master
+          run_sync
+          grep -q 'Carrying Brave-only files:' "${ROOT}/last.log"
+          sync_verify
+          test -e brave_only.txt
+          grep -q 'third' code.txt
+          assert_github_untouched
+          echo "SCENARIO 5 (brave-only carry): PASS"
+
+          echo "ALL SCENARIOS PASS"


### PR DESCRIPTION
## Problem

Automated mirror sync ([run 33701207368](https://github.com/brave/uBlock/actions/runs/33701207368)) fails:

```
refusing to allow a GitHub App to create or update workflow `.github/workflows/RELEASE.HEAD.md` without `workflows` permission
```

Root cause: the `mirror` branch no longer exists (auto-deleted when PR #328, whose head was `mirror`, merged). In that bootstrap path the old rebase-based script pushed raw upstream history, whose commits touch `.github/workflows/` — rejected because `GITHUB_TOKEN` lacks the `workflows` permission.

## Fix

**`.github/sync_mirror.sh`** — rewritten. The mirror branch is now `origin/master` plus **one squashed sync commit** per run:

- parent = current `origin/master` tip
- tree = upstream tree with `.github/` swapped for master's, and Brave-only files (on master, not upstream) carried over
- commit message records the full synced upstream SHA

The sync commit never modifies `.github/` relative to its parent, so the push is always accepted (GitHub only rejects pushes whose *new* commits touch workflow files). This also keeps the master←mirror merge free of `.github/` conflicts.

Other properties:
- **Self-healing**: if `mirror` is deleted, the next run bootstraps from the current master tip.
- Upstream deletions are honored (files upstream removed since the last sync are not resurrected from master).
- No-op detection: nothing is pushed when the sanitized tree already matches master or the existing mirror.
- `--force-with-lease` guards concurrent runs; `SANITIZE=0` remains as a break-glass escape hatch.
- `shellcheck`-clean.

**`.github/workflows/test-sync-steps.yml`** — `test-sync-sanitize` rewritten for the new mechanism. Builds temp upstream/origin repos and exercises 5 scenarios: bootstrap with mixed changes, workflow-only no-op, incremental sync with upstream deletion, self-heal after mirror deletion, and Brave-only file carry.

`sync-from-fork.yml` needs no changes (env/contract unchanged).

## Testing

All 5 scenarios pass against git 2.53 (CI parity), plus a real-data run against gorhill/uBlock → brave/uBlock: sync commit built with 18 upstream code files and 0 `.github/` paths in `master..mirror`, second run no-ops.